### PR TITLE
Resolves An Issue With Paramters Not Detected

### DIFF
--- a/logging-context-aspect/src/main/java/io/github/logcontext/aop/LoggingContextAdvice.java
+++ b/logging-context-aspect/src/main/java/io/github/logcontext/aop/LoggingContextAdvice.java
@@ -83,7 +83,7 @@ public class LoggingContextAdvice {
     if (joinPoint.getSignature() instanceof MethodSignature) {
       MethodSignature ms = (MethodSignature) joinPoint.getSignature();
       final Class<?> clazz = joinPoint.getTarget().getClass();
-      final Method method = ms.getMethod();
+      final Method method = clazz.getMethod(ms.getName(), ms.getParameterTypes());
 
       final Builder contextBuilder = Builder.builder();
 

--- a/logging-context-aspect/src/test/java/io/github/logcontext/aop/LoggingContextAdviceTest.java
+++ b/logging-context-aspect/src/test/java/io/github/logcontext/aop/LoggingContextAdviceTest.java
@@ -274,6 +274,8 @@ class LoggingContextAdviceTest {
     final ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
     final MethodSignature signature = mock(MethodSignature.class);
 
+    when(signature.getName()).thenReturn(method.getName());
+    when(signature.getParameterTypes()).thenReturn(method.getParameterTypes());
     when(signature.getMethod()).thenReturn(method);
 
     when(joinPoint.getTarget()).thenReturn(target);

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
     <java.version>1.8</java.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.release>8</maven.compiler.release>
 
     <aspectj.version>[1.8.9,)</aspectj.version>
     <log4j12.version>2.10.0</log4j12.version>
@@ -77,6 +76,16 @@
       <modules>
         <module>examples</module>
       </modules>
+    </profile>
+
+    <profile>
+      <id>JDK9+</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>8</maven.compiler.release>
+      </properties>
     </profile>
 
     <profile>


### PR DESCRIPTION
Resolves an error where in some situations the parameters are not being added to the logging context. The issue stems from the fact that the Method provided to the advice may not have all of the method and parameter annotations. This is resolved by pulling a reference to the Method from the target class based on the method signature which does include the original annotations.